### PR TITLE
Bugfix/fixed incorrect coverage stats

### DIFF
--- a/tests/spec.test.js
+++ b/tests/spec.test.js
@@ -35,28 +35,18 @@ test.before(() => {
       }
     }
   });
-  handler.addMockInteractionHandler('get ninjas by rank and name', (ctx) => {
+  handler.addMockInteractionHandler('get ninja by rank and name', (ctx) => {
     return {
       withRequest: {
         method: 'GET',
-        path: `/api/server/v1/getninjas/${ctx.data.rank}/${ctx.data.name}`
+        path: `/api/server/v1/getninja/${ctx.data.rank}/${ctx.data.name}`
       },
       willRespondWith: {
         status: 200
       }
     }
   });
-  handler.addMockInteractionHandler('get ninja by name', (ctx) => {
-    return {
-      withRequest: {
-        method: 'GET',
-        path: `/api/server/v1/getninjabyname/${ctx.data}`
-      },
-      willRespondWith: {
-        status: 200
-      }
-    }
-  });
+
   handler.addMockInteractionHandler('get health', () => {
     return {
       withRequest: {
@@ -89,15 +79,6 @@ test('spec passed - additional path params', async () => {
     .expectStatus(200);
 });
 
-
-test('spec passed - additional path params variation', async () => {
-  await pactum.spec()
-    .useMockInteraction('get ninja by name', "kakashi")
-    .get('/api/server/v1/getninjabyname/kakashi')
-    .expectStatus(200);
-});
-
-
 test('spec passed - no path params', async () => {
   await pactum.spec()
     .useMockInteraction('get health')
@@ -107,8 +88,8 @@ test('spec passed - no path params', async () => {
 
 test('spec passed - different api path with path params', async () => {
   await pactum.spec()
-    .useMockInteraction('get ninjas by rank and name', {rank: "jounin", name: "kakashi"})
-    .get('/api/server/v1/getninjas/jounin/kakashi')
+    .useMockInteraction('get ninja by rank and name', {rank: "jounin", name: "kakashi"})
+    .get('/api/server/v1/getninja/jounin/kakashi')
     .expectStatus(200);
 });
 
@@ -137,11 +118,11 @@ test('validate json reporter', async () => {
   assert.equal(report.hasOwnProperty("totalApiCount"), true)
   assert.equal(report.hasOwnProperty("coveredApiList"), true)
   assert.equal(report.hasOwnProperty("missedApiList"), true)
-  assert.equal(report.coverage, 0.7142857142857142);
-  assert.equal(report.coveredApiCount, 5);
+  assert.equal(report.coverage, 0.6666666666666666);
+  assert.equal(report.coveredApiCount, 4);
   assert.equal(report.missedApiCount, 2);
-  assert.equal(report.totalApiCount, 7);
-  assert.equal(report.coveredApiList.length, 5);
+  assert.equal(report.totalApiCount, 6);
+  assert.equal(report.coveredApiList.length, 4);
   assert.equal(report.missedApiList.length, 2);
 });
 

--- a/tests/spec.test.js
+++ b/tests/spec.test.js
@@ -13,11 +13,55 @@ test.before(() => {
   psc.file = 'report.json'
   reporter.add(psc);
   request.setBaseUrl('http://localhost:9393');
-  handler.addMockInteractionHandler('get ninjas', () => {
+  handler.addMockInteractionHandler('get all ninjas', () => {
     return {
       withRequest: {
         method: 'GET',
         path: '/api/server/v1/getallninjas'
+      },
+      willRespondWith: {
+        status: 200
+      }
+    }
+  });
+  handler.addMockInteractionHandler('get ninjas by rank', (ctx) => {
+    return {
+      withRequest: {
+        method: 'GET',
+        path: `/api/server/v1/getninjas/${ctx.data}`
+      },
+      willRespondWith: {
+        status: 200
+      }
+    }
+  });
+  handler.addMockInteractionHandler('get ninjas by rank and name', (ctx) => {
+    return {
+      withRequest: {
+        method: 'GET',
+        path: `/api/server/v1/getninjas/${ctx.data.rank}/${ctx.data.name}`
+      },
+      willRespondWith: {
+        status: 200
+      }
+    }
+  });
+  handler.addMockInteractionHandler('get ninja by name', (ctx) => {
+    return {
+      withRequest: {
+        method: 'GET',
+        path: `/api/server/v1/getninjabyname/${ctx.data}`
+      },
+      willRespondWith: {
+        status: 200
+      }
+    }
+  });
+  handler.addMockInteractionHandler('get health', () => {
+    return {
+      withRequest: {
+        method: 'GET',
+        path: `/api/server/v1/health`
       },
       willRespondWith: {
         status: 200
@@ -33,8 +77,38 @@ test.after(() => {
 
 test('spec passed', async () => {
   await pactum.spec()
-    .useMockInteraction('get ninjas')
+    .useMockInteraction('get all ninjas')
     .get('/api/server/v1/getallninjas')
+    .expectStatus(200);
+});
+
+test('spec passed - additional path params', async () => {
+  await pactum.spec()
+    .useMockInteraction('get ninjas by rank', "jounin")
+    .get('/api/server/v1/getninjas/jounin')
+    .expectStatus(200);
+});
+
+
+test('spec passed - additional path params variation', async () => {
+  await pactum.spec()
+    .useMockInteraction('get ninja by name', "kakashi")
+    .get('/api/server/v1/getninjabyname/kakashi')
+    .expectStatus(200);
+});
+
+
+test('spec passed - no path params', async () => {
+  await pactum.spec()
+    .useMockInteraction('get health')
+    .get('/api/server/v1/health')
+    .expectStatus(200);
+});
+
+test('spec passed - different api path with path params', async () => {
+  await pactum.spec()
+    .useMockInteraction('get ninjas by rank and name', {rank: "jounin", name: "kakashi"})
+    .get('/api/server/v1/getninjas/jounin/kakashi')
     .expectStatus(200);
 });
 
@@ -42,16 +116,6 @@ test('spec failed', async () => {
   try {
     await pactum.spec()
       .get('/api/server/v1/getallninjas')
-      .expectStatus(200);
-  } catch (error) {
-    console.log(error);
-  }
-});
-
-test('spec error', async () => {
-  try {
-    await pactum.spec()
-      .get('http://localhost:9001/api/user')
       .expectStatus(200);
   } catch (error) {
     console.log(error);
@@ -73,12 +137,12 @@ test('validate json reporter', async () => {
   assert.equal(report.hasOwnProperty("totalApiCount"), true)
   assert.equal(report.hasOwnProperty("coveredApiList"), true)
   assert.equal(report.hasOwnProperty("missedApiList"), true)
-  assert.equal(report.coverage, 0.2);
-  assert.equal(report.coveredApiCount, 1);
-  assert.equal(report.missedApiCount, 4);
-  assert.equal(report.totalApiCount, 5);
-  assert.equal(report.coveredApiList.length, 1);
-  assert.equal(report.missedApiList.length, 4);
+  assert.equal(report.coverage, 0.7142857142857142);
+  assert.equal(report.coveredApiCount, 5);
+  assert.equal(report.missedApiCount, 2);
+  assert.equal(report.totalApiCount, 7);
+  assert.equal(report.coveredApiList.length, 5);
+  assert.equal(report.missedApiList.length, 2);
 });
 
 test.run();

--- a/tests/testObjects/swagger.yaml
+++ b/tests/testObjects/swagger.yaml
@@ -91,6 +91,47 @@ paths:
             $ref: "#/definitions/Health"
     x-swagger-router-controller: "test.controller" 
   
+  /getninjas/{rank}:
+    get:
+      tags: ["Ninjas"]
+      description: "Get Ninja details by Rank"
+      operationId: "getNinjaByRank"
+      parameters:
+        - name: rank
+          in: path
+          type: string
+          description: Rank of Ninja
+          required: true
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/Health"
+    x-swagger-router-controller: "test.controller" 
+  
+  /getninjas/{rank}/{name}:
+    get:
+      tags: ["Ninjas"]
+      description: "Get Ninja details by Rank"
+      operationId: "getNinjaByRank"
+      parameters:
+        - name: name
+          in: path
+          type: string
+          description: Name of Ninja
+          required: true
+        - name: rank
+          in: path
+          type: string
+          description: Rank of Ninja
+          required: true
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/Health"
+    x-swagger-router-controller: "test.controller" 
+
 definitions:
   Health:
     description: "Health Response"

--- a/tests/testObjects/swagger.yaml
+++ b/tests/testObjects/swagger.yaml
@@ -36,60 +36,6 @@ paths:
           schema:
             $ref: "#/definitions/Health"
     x-swagger-router-controller: "test.controller"    
-
-  /getninjabyid/{id}:
-    get:
-      tags: ["Ninjas"]
-      description: "Get All Ninjas"
-      operationId: "getNinjaById"
-      parameters:
-        - name: id
-          in: path
-          type: integer
-          description: Id of Ninja
-          required: true
-      responses:
-        200:
-          description: "Success"
-          schema:
-            $ref: "#/definitions/Health"
-    x-swagger-router-controller: "test.controller" 
-
-  /getninjabyname/{name}:
-    get:
-      tags: ["Ninjas"]
-      description: "Get Ninja details by Name"
-      operationId: "getNinjaByName"
-      parameters:
-        - name: name
-          in: path
-          type: string
-          description: Name of Ninja
-          required: true
-      responses:
-        200:
-          description: "Success"
-          schema:
-            $ref: "#/definitions/Health"
-    x-swagger-router-controller: "test.controller" 
-
-  /getninjabyrank/{rank}:
-    get:
-      tags: ["Ninjas"]
-      description: "Get Ninja details by Rank"
-      operationId: "getNinjaByRank"
-      parameters:
-        - name: rank
-          in: path
-          type: string
-          description: Rank of Ninja
-          required: true
-      responses:
-        200:
-          description: "Success"
-          schema:
-            $ref: "#/definitions/Health"
-    x-swagger-router-controller: "test.controller" 
   
   /getninjas/{rank}:
     get:
@@ -108,11 +54,34 @@ paths:
           schema:
             $ref: "#/definitions/Health"
     x-swagger-router-controller: "test.controller" 
-  
-  /getninjas/{rank}/{name}:
+
+  /getninjas/{clan}/{rank}:
     get:
       tags: ["Ninjas"]
-      description: "Get Ninja details by Rank"
+      description: "Get Ninja details by Clan and Rank"
+      operationId: "getNinjaByRank"
+      parameters:
+        - name: clan
+          in: path
+          type: string
+          description: Clan of Ninja
+          required: true
+        - name: rank
+          in: path
+          type: string
+          description: Rank of Ninja
+          required: true
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/Health"
+    x-swagger-router-controller: "test.controller" 
+  
+  /getninja/{name}:
+    get:
+      tags: ["Ninjas"]
+      description: "Get Ninja details by Name"
       operationId: "getNinjaByRank"
       parameters:
         - name: name
@@ -120,10 +89,28 @@ paths:
           type: string
           description: Name of Ninja
           required: true
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/Health"
+    x-swagger-router-controller: "test.controller" 
+  
+  /getninja/{rank}/{name}:
+    get:
+      tags: ["Ninjas"]
+      description: "Get Ninja details by Rank and name"
+      operationId: "getNinjaByRank"
+      parameters:
         - name: rank
           in: path
           type: string
           description: Rank of Ninja
+          required: true
+        - name: name
+          in: path
+          type: string
+          description: Name of Ninja
           required: true
       responses:
         200:


### PR DESCRIPTION
Changes:
* Fixed regex and logic of matching api paths
* Added function descriptions in `core.js`
* Updated tests
* Updated mock swagger definition


Sample o/p report:

```json
{
  "basePath": "/api/server/v1",
  "coverage": 0.6666666666666666,
  "coveredApiCount": 4,
  "missedApiCount": 2,
  "totalApiCount": 6,
  "coveredApiList": [
    "/api/server/v1/health",
    "/api/server/v1/getallninjas",
    "/api/server/v1/getninjas/{rank}",
    "/api/server/v1/getninja/{rank}/{name}"
  ],
  "missedApiList": [
    "/api/server/v1/getninjas/{clan}/{rank}",
    "/api/server/v1/getninja/{name}"
  ]
}
```

PS: API's mocked with pactum mock server and reside in tests: https://github.com/pactumjs/pactum-swagger-coverage/blob/bugfix/fixed-incorrect-coverage-stats/tests/spec.test.js
