### PR TITLE
Make the basePath parameter accessible to TypeScript users

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 import { name } from "."
 
+export let basePath: string;
 export let name: string;
 export let reportPath: string;
 export let file: string;


### PR DESCRIPTION
Include the basePath parameter in the src/index.d.ts file so that TypeScript users can access it.